### PR TITLE
Add documentation and tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,13 @@
 import * as vscode from 'vscode';
 import { BinaryImageEditorProvider } from './binaryImageEditorProvider';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
+/**
+ * Called when the extension is activated. This happens the first time the
+ * command is executed or when a registered file type is opened.
+ *
+ * @param context VS Code extension context used for subscriptions and access
+ * to extension resources.
+ */
 export function activate(context: vscode.ExtensionContext) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
@@ -36,5 +41,9 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(providerRegistration, disposable);
 }
 
-// This method is called when your extension is deactivated
+/**
+ * Clean up resources when the extension is deactivated. Currently this
+ * extension has no teardown logic but the function is provided for
+ * completeness.
+ */
 export function deactivate() {}

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { BinaryImageEditorProvider } from '../binaryImageEditorProvider';
+
+describe('BinaryImageEditorProvider', () => {
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const provider = new BinaryImageEditorProvider(context);
+
+    it('getBytesPerPixel returns expected values', () => {
+        const asAny = provider as any;
+        assert.strictEqual(asAny.getBytesPerPixel('uint8'), 1);
+        assert.strictEqual(asAny.getBytesPerPixel('uint16'), 2);
+        assert.strictEqual(asAny.getBytesPerPixel('int16'), 2);
+        assert.strictEqual(asAny.getBytesPerPixel('float32'), 4);
+        assert.strictEqual(asAny.getBytesPerPixel('int32'), 4);
+        assert.strictEqual(asAny.getBytesPerPixel('float64'), 8);
+        assert.strictEqual(asAny.getBytesPerPixel('unknown'), 4);
+    });
+
+    it('calculateMaxSlices computes correct slice count', () => {
+        const asAny = provider as any;
+        const fileSize = 200;
+        const slices = asAny.calculateMaxSlices(fileSize, 10, 5, 'uint8');
+        assert.strictEqual(slices, 4);
+    });
+
+    it('openCustomDocument returns a document with the same URI', async () => {
+        const uri = vscode.Uri.file('/tmp/test.raw');
+        const doc = await provider.openCustomDocument(uri, {} as any, {} as any);
+        assert.strictEqual(doc.uri.fsPath, uri.fsPath);
+        assert.ok(typeof doc.dispose === 'function');
+    });
+});

--- a/test/stubs/vscode.js
+++ b/test/stubs/vscode.js
@@ -1,0 +1,14 @@
+exports.Uri = class {
+    constructor(fsPath){ this.fsPath = fsPath; }
+    static file(p){ return new exports.Uri(p); }
+    toString(){ return this.fsPath; }
+};
+exports.workspace = {
+    fs: {
+        async readFile(){ return new Uint8Array(); },
+        async stat(){ return { size: 0 }; }
+    }
+};
+exports.window = {
+    registerCustomEditorProvider: () => ({})
+};


### PR DESCRIPTION
## Summary
- document functions in extension and provider
- add a unit test covering BinaryImageEditorProvider internals
- add stub vscode module for tests

## Testing
- `NODE_PATH=./test/stubs npx mocha out/test/provider.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685524f1e6a0832abd92f81d45b741f3