### PR TITLE
Fix missing initial file info in webview

### DIFF
--- a/src/binaryImageEditorProvider.ts
+++ b/src/binaryImageEditorProvider.ts
@@ -54,9 +54,6 @@ export class BinaryImageEditorProvider implements vscode.CustomReadonlyEditorPro
             enableScripts: true,
         };
 
-        // Set the HTML content
-        webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
-
         // Handle messages from the webview
         webviewPanel.webview.onDidReceiveMessage(
             async (message) => {
@@ -82,6 +79,10 @@ export class BinaryImageEditorProvider implements vscode.CustomReadonlyEditorPro
             undefined,
             this.context.subscriptions
         );
+
+        // Set the HTML content after registering the message listener to ensure
+        // we receive the initial 'ready' message from the webview.
+        webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
     }
 
     /**


### PR DESCRIPTION
## Summary
- register webview message listener before assigning HTML
- ensure the provider receives the initial `ready` message to send file info

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a72d1084832a883cd92c04ffae9a