### PR TITLE
Add window/level controls with reset button

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,8 @@
 - [x] Develop slice navigation control: slider, mouse scroll, ←/→ keyboard shortcuts
 
 ## Milestone 3
-- [ ] Implement window/level controls with draggable min/max handles
-- [ ] Add “Reset” button to restore original window/level (default to full range)
+ - [x] Implement window/level controls with draggable min/max handles
+ - [x] Add “Reset” button to restore original window/level (default to full range)
 
 ## Milestone 4
 - [ ] Add “Auto-window” button (percentile-based, 90% range)

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -24,6 +24,21 @@ describe('BinaryImageEditorProvider', () => {
         assert.strictEqual(slices, 4);
     });
 
+    it('applyWindowLevel maps values into 0-255 range', () => {
+        const asAny = provider as any;
+        const values = [0, 50, 100, 150];
+        const mapped = asAny.applyWindowLevel(values, 0, 100);
+        assert.deepStrictEqual(Array.from(mapped), [0, 128, 255, 255]);
+    });
+
+    it('generated HTML includes window controls', () => {
+        const asAny = provider as any;
+        const html: string = asAny.getHtmlForWebview({} as any);
+        assert.ok(html.includes('id="windowMin"'));
+        assert.ok(html.includes('id="windowMax"'));
+        assert.ok(html.includes('id="resetWindow"'));
+    });
+
     it('openCustomDocument returns a document with the same URI', async () => {
         const uri = vscode.Uri.file('/tmp/test.raw');
         const doc = await provider.openCustomDocument(uri, {} as any, {} as any);


### PR DESCRIPTION
## Summary
- implement applyWindowLevel and findMinMax helpers
- expose window/level sliders and Reset button in the webview
- add JS logic for updating and resetting window level
- update tests to cover windowing
- mark milestone 3 in TODO as complete

## Testing
- `npm run compile-tests`
- `npm run compile`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858b7813448832a9ce4ca10ef4cdf0d