### PR TITLE
Use WebGL for viewer rendering

### DIFF
--- a/src/binaryImageEditorProvider.ts
+++ b/src/binaryImageEditorProvider.ts
@@ -909,6 +909,14 @@ export class BinaryImageEditorProvider implements vscode.CustomReadonlyEditorPro
             const shader = gl.createShader(type);
             gl.shaderSource(shader, source);
             gl.compileShader(shader);
+            
+            // Check shader compilation status
+            if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+                console.error('Shader compilation failed: ', gl.getShaderInfoLog(shader));
+                gl.deleteShader(shader);
+                return null; // Return null to indicate failure
+            }
+            
             return shader;
         }
 

--- a/src/binaryImageEditorProvider.ts
+++ b/src/binaryImageEditorProvider.ts
@@ -672,6 +672,7 @@ export class BinaryImageEditorProvider implements vscode.CustomReadonlyEditorPro
         const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
         if (!gl) {
             console.error('WebGL not supported');
+            return;
         }
         let program = null;
         let positionBuffer = null;


### PR DESCRIPTION
## Summary
- replace 2D canvas context with WebGL2
- add shader based rendering pipeline
- upload slice data as textures and apply window/level in shaders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dfced40f4832ab3fde5ee3dc29c8c